### PR TITLE
feat: Gitの属性にて対象ファイルにSJISを指定する

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sjis_file.txt diff=sjis


### PR DESCRIPTION
## 概要
- GitにてSJISのファイルを比較する際に文字化けしないようにする

## ローカル環境において
- `git diff`時に変換を行うようにする
   - https://git-scm.com/docs/gitattributes#_performing_text_diffs_of_binary_files

### 手順
1. `.gitattributes`にて変換対象のファイルのdiff実行時の設定を指定する
   ```sh
   % cat .gitattributes 
   sjis_file.txt diff=sjis
   %
   ```
1. `.gitattributes`にて指定した設定の場合の変換方法を指定する
      ```sh
      $ git config diff.sjis.textconv "nkf -w"
      $ git config --get diff.sjis.textconv
      nkf -w
      ```

### 結果
```zsh
% git diff 6759c5e2cf828482ff202436a3fd5fd976e211c9 a1e86418283876c9b0026cfd95cb4f45d962dacf verification/diff/sjis_file.txt
diff --git a/verification/diff/sjis_file.txt b/verification/diff/sjis_file.txt
index cdd6606..7758e0d 100644
--- a/verification/diff/sjis_file.txt
+++ b/verification/diff/sjis_file.txt
@@ -1,2 +1,2 @@
 こファイルはSJISで記載されています。
-改行コードはなんらなCRLFです。
+改行コードはなんならCRLFです。^M
% 
```

### 参考
- [diff.\<driver\>.textconv](https://git-scm.com/docs/git-config#Documentation/git-config.txt-diffltdrivergttextconv)

## GitHubのPullRequestにおいて
